### PR TITLE
ENG-1074 Release workflow for rules

### DIFF
--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -1,0 +1,32 @@
+---
+name: Generate Amplify Ruleset
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: github.repository == 'amplify-security/opengrep-rules'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: '3.13'
+      - run: pip3 install pyyaml
+      - name: generate Amplify rule set
+        run: python3 scripts/generate-amplify-ruleset.py
+      - name: update latest release
+        # yes, this action is no longer maintained.
+        uses: marvinpinto/action-automatic-releases@40312c52f0ca0d0589b25e8f5172a3613f0759c3
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: latest
+          prerelease: true
+          files: |
+            rules.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .DS_Store
 .vscode/
 .venv
+
+rules.json

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,3 @@
+yaml:
+  rules:
+    line-length: disable 

--- a/scripts/generate-amplify-ruleset.py
+++ b/scripts/generate-amplify-ruleset.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import os
+import json
+import yaml
+
+def load_configs():
+    directory = 'configs'
+    data = []
+    for filename in os.listdir(directory):
+        if filename.endswith(".list"):
+            with open(os.path.join(directory, filename), 'r') as file:
+                for line in file:
+                    data.append(tuple(line.strip().split(':')))
+    print(f'I:loaded {len(data)} rules from configs, removing {len(data) - len(set(data))} duplicates')
+    # There is some rule overlap in our configuration lists, so this dedups the list
+    return set(data)
+
+def collect_rules(rule_list):
+    accumulated_rules = []
+    for item in rule_list:
+        rules_file, rule_id = item
+        rule_prefix = rules_file.replace('/', '.').replace('.yaml', '')
+        if os.path.isfile(rules_file):
+            with open(rules_file, 'r') as yaml_file:
+                yaml_data = yaml.safe_load(yaml_file)
+                if 'rules' in yaml_data:
+                    rule_found = False
+                    for rule in yaml_data['rules']:
+                        if rule.get('id') == rule_id:
+                            rule['id'] = f'{rule_prefix}.{rule_id}'
+                            accumulated_rules.append(rule)
+                            rule_found = True
+                    if not rule_found:
+                        print(f'W:rule {rule_id} not found in {rules_file}')
+                else:
+                    print(f'E:unable to load rule {rule_id} as {rules_file} does not appear to contain rules')
+        else:
+            print(f'W:skipping {item} as {rules_file} does not exist')
+
+    return accumulated_rules
+
+def main():
+    rule_list = load_configs()
+    rules = collect_rules(rule_list)
+    print(f'I:collected {len(rules)} rules')
+
+    with open('rules.json', 'w') as json_file:
+        json.dump({'rules': rules}, json_file)
+        print('I:rules written to rules.json')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a script that collects a list of rules from the `configs` directory and generates a JSON file that contains the configuration for those rules, and adds a Github Action workflow that publishes them to the `latest` tag/release on every push.
